### PR TITLE
Added changes for removing/cleaning Job template properly

### DIFF
--- a/roles/ansible_tower/includes/init.yaml
+++ b/roles/ansible_tower/includes/init.yaml
@@ -13,3 +13,8 @@
   fail:
     msg: "missing required variable: tower_password"
   when: tower_password is undefined
+
+- name: validate tower_state is set
+  fail:
+    msg: "missing required variable: tower_state"
+  when: tower_state is undefined

--- a/roles/ansible_tower/includes/job_template.yaml
+++ b/roles/ansible_tower/includes/job_template.yaml
@@ -51,6 +51,21 @@
         tower_password: "{{ tower_password }}"
         tower_verify_ssl: "{{ tower_verify_ssl | default(omit) }}"
 
+    - name: remove job templates
+      tower_job_template:
+        name: "{{ item.name }}"
+        playbook: "{{ item.playbook }}"
+        project: "{{ item.project }}"
+        job_type: "{{ item.job_type }}"
+        state: "{{ item.state | default(omit) }}"
+        tower_host: "{{ tower_host }}"
+        tower_username: "{{ tower_username }}"
+        tower_password: "{{ tower_password }}"
+        tower_verify_ssl: "{{ tower_verify_ssl | default(omit) }}"
+      when:
+      - item.state is defined
+      - item.state == 'absent'
+
       # job_templates in tower support 'admin', 'execute', and 'read'
       # permissions
     - name: assign permissions to team

--- a/roles/ansible_tower/tasks/main.yml
+++ b/roles/ansible_tower/tasks/main.yml
@@ -73,5 +73,15 @@
         - ansible_tower.job_templates is defined
       tags:
         - job_templates
+
+    - name: configure projects
+      include_tasks: "{{ role_path }}/includes/project.yaml"
+      loop: "{{ ansible_tower.projects }}"
+      when:
+        - ansible_tower.projects is defined
+        - tower_state == 'absent'
+      tags:
+        - project_clean
+
   when:
     - ansible_tower is defined


### PR DESCRIPTION
- Changes include for removal of `job_template` before `project` is removed as in current scenario `project` is getting deleted before `job_template` and `project` being required parameter for removal of `job_template`, the error `requested not found` was thrown.